### PR TITLE
Allow a custom salt length in `GenerateSalt()`.

### DIFF
--- a/src/srp/ISrpClient.cs
+++ b/src/srp/ISrpClient.cs
@@ -8,7 +8,11 @@
 		/// <summary>
 		/// Generates the random salt of the same size as a used hash.
 		/// </summary>
-		string GenerateSalt();
+    /// <param name="saltLength">
+		/// An optional, custom salt length specifying the number of bytes. If it is unset,
+		/// the `HashSizeBytes` of the hash function from the `Parameters` will be used.
+		//// </param>
+		string GenerateSalt(int? saltLength = null);
 
 		/// <summary>
 		/// Derives the private key from the given salt, user name and password.

--- a/src/srp/SrpClient.cs
+++ b/src/srp/SrpClient.cs
@@ -24,9 +24,13 @@ namespace SecureRemotePassword
 		/// <summary>
 		/// Generates the random salt of the same size as a used hash.
 		/// </summary>
-		public string GenerateSalt()
+		/// <param name="saltLength">
+		/// An optional, custom salt length specifying the number of bytes. If it is unset,
+		/// the `HashSizeBytes` of the hash function from the `Parameters` will be used.
+		//// </param>
+		public string GenerateSalt(int? saltLength = null)
 		{
-			var hashSize = Parameters.HashSizeBytes;
+			var hashSize = saltLength ?? Parameters.HashSizeBytes;
 			return SrpInteger.RandomInteger(hashSize).ToHex();
 		}
 


### PR DESCRIPTION
I'm working with an SRP implementation that uses a custom salt length that differs from `HashSizeBytes`. Other SRP implementations (e.g. python) allow this. (source: https://github.com/cocagne/pysrp/blob/master/srp/_pysrp.py#L224).

This value is optional, so if unset it will just fallback to `Parameters.HashSizeBytes` as the default.

I worked around this locally by calling directly in to `SrpInteger.RandomInteger()` in my code, but it reads much better to be able to do something like:

```
client.GenerateSalt(saltLength: 256)
```