### PR TITLE
Support custom hashes in browser and less than netstandard1.6

### DIFF
--- a/src/srp.tests/SrpHashTests.cs
+++ b/src/srp.tests/SrpHashTests.cs
@@ -42,7 +42,22 @@ namespace SecureRemotePassword.Tests
 			var sha512 = SrpHash.CreateHasher("sha512");
 			Assert.NotNull(sha512);
 		}
+		
+		#if NETCOREAPP2_0_OR_GREATER
+		[Test]
+		public void CreateHasherByRegisteredNameTests()
+		{
+			const string hashName = "MyHasher";
+			var custom = SrpHash.CreateHasher(hashName);
+			Assert.Null(custom);
 
+			CryptoConfig.AddAlgorithm(typeof(SHA256Managed), hashName);
+
+			custom = SrpHash.CreateHasher(hashName);
+			Assert.NotNull(custom);
+		}
+		#endif
+		
 		[Test]
 		public void SrpHashComputesValidStringHashes()
 		{

--- a/src/srp/CryptoConfig.cs
+++ b/src/srp/CryptoConfig.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SecureRemotePassword
+{
+	/// <summary>
+	/// An alternative cryptographic configuration for .netstandard1.6 and browser runtimes.
+	/// </summary>
+	public static class CryptoConfig
+	{
+		private static readonly IDictionary<string, Type> CryptoRegistry = new Dictionary<string, Type>();
+
+		/// <summary>
+		/// Creates a new instance of the specified cryptographic object.
+		/// </summary>
+		/// <param name="name">The simple name of the cryptographic object of which to create an instance.</param>
+		/// <returns>A new instance of the specified cryptographic object.</returns>
+		public static object CreateFromName(string name)
+		{
+			if (!CryptoRegistry.TryGetValue(name, out Type type))
+			{
+				return default(System.Security.Cryptography.HashAlgorithm);
+			}
+
+			return Activator.CreateInstance(type);
+		}
+
+		/// <summary>
+		/// Adds a set of names to algorithm mappings to be used for the current application domain.
+		/// </summary>
+		/// <param name="algorithm">The algorithm to map to.</param>
+		/// <param name="names">An array of names to map to the algorithm.</param>
+		public static void AddAlgorithm(Type algorithm, params string[] names)
+		{
+			foreach (string name in names)
+			{
+				CryptoRegistry[name] = algorithm;
+			}
+		}
+	}
+}

--- a/src/srp/SrpHash.cs
+++ b/src/srp/SrpHash.cs
@@ -61,11 +61,14 @@ namespace SecureRemotePassword
 		{
 			var result = default(HashAlgorithm);
 
-			// CryptoConfig is not available on .NET Standard 1.6
-			#if USE_CRYPTO_CONFIG
+			// CryptoConfig is not available on .NET Standard 1.6 or browser runtimes.
 			result = (HashAlgorithm)CryptoConfig.CreateFromName(algorithm);
+			#if USE_CRYPTO_CONFIG
+			if (result == null)
+			{
+				result = (HashAlgorithm)System.Security.Cryptography.CryptoConfig.CreateFromName(algorithm);
+			}
 			#endif
-
 			if (result == null)
 			{
 				switch (algorithm.ToLowerInvariant())


### PR DESCRIPTION
For an upcoming project I needed to support SRP and SHA3 in Blazor WASM. Unfortunately, CryptoConfig is unavailable in the browser. This adds another registration layer for custom hashes. I didn't want to change the public API and force a major version bump. Open to suggestions on alternatives.